### PR TITLE
Remove development dependency versions

### DIFF
--- a/restcountry.gemspec
+++ b/restcountry.gemspec
@@ -23,8 +23,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.8"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "rake"
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency "vcr"
   spec.add_development_dependency "typhoeus"


### PR DESCRIPTION
Specify a version only when gems have some installation troubles.